### PR TITLE
Related items

### DIFF
--- a/client/dist/styles/relatedProducts.css
+++ b/client/dist/styles/relatedProducts.css
@@ -46,6 +46,14 @@
   order: 5;
 }
 
+.originalProductPriceWithSale {
+  text-decoration: line-through;
+}
+
+.saleProductPrice {
+  color: red;
+}
+
 img {
   width: 250px;
   height: 300px;

--- a/client/src/Overview/components/ImageGallery.jsx
+++ b/client/src/Overview/components/ImageGallery.jsx
@@ -63,7 +63,7 @@ const ImageGallery = (props) => {
                   return (
                     <div className = "main-image">
                       {function() {
-                        console.log('left', props.OverviewState.mainPhoto)
+                        //console.log('left', props.OverviewState.mainPhoto)
                         if (props.OverviewState.mainPhoto > 0) {
                           return (
                             <button className = "main-image-left-arrow" onClick = {props.mainImageLeftArrow}>{function() {

--- a/client/src/helper-functions/rpHelpers.js
+++ b/client/src/helper-functions/rpHelpers.js
@@ -1,6 +1,6 @@
 const helper = {
   compileRelatedProductsDataToProps: (relatedProducts, relatedProductsStyles, starRating) => {
-    console.log(JSON.stringify(starRating));
+
     let allPropsObj = {};
     let relatedProductsCopy = Object.assign(relatedProducts);
     let relatedProductsStylesCopy= Object.assign(relatedProductsStyles);

--- a/client/src/helper-functions/rpHelpers.js
+++ b/client/src/helper-functions/rpHelpers.js
@@ -1,5 +1,6 @@
 const helper = {
-  compileRelatedProductsDataToProps: (relatedProducts, relatedProductsStyles) => {
+  compileRelatedProductsDataToProps: (relatedProducts, relatedProductsStyles, starRating) => {
+    console.log(JSON.stringify(starRating));
     let allPropsObj = {};
     let relatedProductsCopy = Object.assign(relatedProducts);
     let relatedProductsStylesCopy= Object.assign(relatedProductsStyles);
@@ -9,6 +10,7 @@ const helper = {
       itemDetail['itemId'] = item['id'];
       itemDetail['itemName'] = item['name'];
       itemDetail['itemCategory'] = item['category'];
+      itemDetail['starRating'] = starRating
 
       allPropsObj[item['id']] = itemDetail;
     })

--- a/client/src/relatedProducts/RelatedProductsView/RelatedProducts.jsx
+++ b/client/src/relatedProducts/RelatedProductsView/RelatedProducts.jsx
@@ -32,11 +32,20 @@ export default class RelatedProducts extends React.Component {
   componentDidMount () {
     this.getRelatedStateData();
     this.getOutfitData();
+    let values = [],
+      keys = Object.keys(localStorage),
+      i = keys.length;
+
+      while ( i-- ) {
+          values.push( JSON.parse(localStorage.getItem(keys[i])) );
+      }
+      this.setState({
+        yourOutfitItems: values
+      })
   }
 
   componentDidUpdate (prevProps, prevState) {
-    if (prevProps.state.product_id !== this.props.state.product_id ||
-        prevState.yourOutfitItems !== this.state.yourOutfitItems) {
+    if (prevProps.state.product_id !== this.props.state.product_id) {
       this.getRelatedStateData();
       this.getOutfitData();
     }
@@ -52,7 +61,6 @@ export default class RelatedProducts extends React.Component {
         productsStyle(productId)
       ])
       .then((results) => {
-        console.log(JSON.stringify(results[1].data));
         let resultStyleWithId = helper.addIdToStylesData(results[1].data, results[0].data.id)
         this.setState({
           relatedProducts: [...this.state.relatedProducts, results[0].data],
@@ -60,7 +68,7 @@ export default class RelatedProducts extends React.Component {
         })
       })
       .then(() => {
-        let allPropsObj = helper.compileRelatedProductsDataToProps(this.state.relatedProducts,this.state.relatedProductsStyles);
+        let allPropsObj = helper.compileRelatedProductsDataToProps(this.state.relatedProducts,this.state.relatedProductsStyles, this.props.state.ratings);
 
         this.setState({
           allPropsObj: allPropsObj,
@@ -106,21 +114,16 @@ export default class RelatedProducts extends React.Component {
 
     handleAddToOutfit (outfitItem, e) {
       e.preventDefault();
-      console.log(`❤️ handler received ${JSON.stringify(outfitItem)}`);
-      console.log(`💙 yourOutfitItemsbefore: ${JSON.stringify(this.state.yourOutfitItems)}`)
-      localStorage.setItem('outfitItem', outfitItem);
-      this.setState({
-        yourOutfitItems: [...this.state.yourOutfitItems, outfitItem]
-      })
-      console.log(`🧡 yourOutfitItemsafter: ${JSON.stringify(this.state.yourOutfitItems)}`)
+      localStorage.setItem(outfitItem.product_id, JSON.stringify(outfitItem));
+
     }
 
 
   render() {
-    if (this.props.state.loaded === false || this.state.loaded === false) {
+    if (this.props.state.loaded === false || this.state.rpLoaded === false || this.state.yoLoaded === false) {
       return <div className='isLoading'>Loading...</div>
     }
-
+    console.log(`allProps: ${JSON.stringify(this.state.allPropsObj)}`)
     return (
       <div className='relatedProducts'>
         <RelatedProductsList

--- a/client/src/relatedProducts/RelatedProductsView/RelatedProducts.jsx
+++ b/client/src/relatedProducts/RelatedProductsView/RelatedProducts.jsx
@@ -25,6 +25,7 @@ export default class RelatedProducts extends React.Component {
 
     }
     this.handleAddToOutfit = this.handleAddToOutfit.bind(this);
+    this.handleRemoveFromOutfit = this.handleRemoveFromOutfit.bind(this);
     this.getRelatedStateData = this.getRelatedStateData.bind(this);
     this.getOutfitData = this.getOutfitData.bind(this);
   }
@@ -36,8 +37,8 @@ export default class RelatedProducts extends React.Component {
       keys = Object.keys(localStorage),
       i = keys.length;
 
-      while ( i-- ) {
-          values.push( JSON.parse(localStorage.getItem(keys[i])) );
+      while (i-- ) {
+        values.push( JSON.parse(localStorage.getItem(keys[i])) );
       }
       this.setState({
         yourOutfitItems: values
@@ -130,6 +131,20 @@ export default class RelatedProducts extends React.Component {
       })
     }
 
+    handleRemoveFromOutfit(outfitItem, e) {
+      e.preventDefault();
+
+      let removedItemId = outfitItem.product_id;
+      let outfitItemsCopy = Object.assign(this.state.yourOutfitItems);
+      let filtered = outfitItemsCopy.filter(product => {
+        return product.product_id !== removedItemId
+      });
+      localStorage.removeItem(removedItemId);
+      this.setState({
+        yourOutfitItems: filtered
+      })
+    }
+
 
   render() {
     if (this.props.state.loaded === false || this.state.rpLoaded === false || this.state.yoLoaded === false) {
@@ -145,6 +160,7 @@ export default class RelatedProducts extends React.Component {
         <YourOutfitList
         outfitProps={this.state.outfitPropsObj}
         handleAddToOutfit={this.handleAddToOutfit}
+        handleRemoveFromOutfit={this.handleRemoveFromOutfit}
         outfitItems={this.state.yourOutfitItems}
         state={this.props.state} />
       </div>

--- a/client/src/relatedProducts/RelatedProductsView/RelatedProducts.jsx
+++ b/client/src/relatedProducts/RelatedProductsView/RelatedProducts.jsx
@@ -123,7 +123,7 @@ export default class RelatedProducts extends React.Component {
     if (this.props.state.loaded === false || this.state.rpLoaded === false || this.state.yoLoaded === false) {
       return <div className='isLoading'>Loading...</div>
     }
-    console.log(`allProps: ${JSON.stringify(this.state.allPropsObj)}`)
+
     return (
       <div className='relatedProducts'>
         <RelatedProductsList

--- a/client/src/relatedProducts/RelatedProductsView/RelatedProducts.jsx
+++ b/client/src/relatedProducts/RelatedProductsView/RelatedProducts.jsx
@@ -48,6 +48,16 @@ export default class RelatedProducts extends React.Component {
     if (prevProps.state.product_id !== this.props.state.product_id) {
       this.getRelatedStateData();
       this.getOutfitData();
+      let values = [],
+      keys = Object.keys(localStorage),
+      i = keys.length;
+
+      while ( i-- ) {
+          values.push( JSON.parse(localStorage.getItem(keys[i])) );
+      }
+      this.setState({
+        yourOutfitItems: values
+      })
     }
   }
 
@@ -115,7 +125,9 @@ export default class RelatedProducts extends React.Component {
     handleAddToOutfit (outfitItem, e) {
       e.preventDefault();
       localStorage.setItem(outfitItem.product_id, JSON.stringify(outfitItem));
-
+      this.setState({
+        yourOutfitItems: [...this.state.yourOutfitItems, outfitItem]
+      })
     }
 
 

--- a/client/src/relatedProducts/RelatedProductsView/RelatedProductsCard.jsx
+++ b/client/src/relatedProducts/RelatedProductsView/RelatedProductsCard.jsx
@@ -3,6 +3,7 @@ import propTypes from 'prop-types';
 import Stars from "../../stars/stars.jsx";
 
 
+
 const getStars = function (starsObject) {
   let total = 0;
   let numberOfRatings = 0;
@@ -19,13 +20,25 @@ const getStars = function (starsObject) {
 };
 
 const RelatedProductsCard = (props) => {
-  //console.log(`rpProps: ${JSON.stringify(props)}`);
+
   return (
     <div className='relatedProductsCard' onClick={() => props.handleProductChange(props.id)} >
         <h2 className='productName'>{props.name}</h2>
         <h3 className='productCategory'>{props.category}</h3>
-        <h3 className='originalProductPrice'>{props.originalPrice}</h3>
-        <h3 className='saleroductPrice'>{props.salePrice}</h3>
+        {(function() {
+          if (props.salePrice === null) {
+            return (
+              <h3 className='originalProductPrice'>{props.originalPrice}</h3>
+            )
+          } else {
+            return (
+              <div className='salePriceWrapper'>
+                <h3 className='originalProductPriceWithSale'>{props.originalPrice}</h3>
+                <h3 className='saleProductPrice'>{props.salePrice}</h3>
+              </div>
+            )
+          }
+        })()}
         <img src={props.photo || 'https://lightwidget.com/wp-content/uploads/local-file-not-found-480x488.png'}></img>
         <div className="reviewStars">{getStars(props.starRating)}</div>
     </div>

--- a/client/src/relatedProducts/RelatedProductsView/RelatedProductsList.jsx
+++ b/client/src/relatedProducts/RelatedProductsView/RelatedProductsList.jsx
@@ -20,7 +20,7 @@ const RelatedProductsList = (props) => {
                photo={product.photoUrl.thumbnail_url}
                id={product.itemId}
                handleProductChange={props.handleProductChange}
-               starRating={props.state.ratings}
+               starRating={product.starRating}
        />
 
        </div>
@@ -34,7 +34,6 @@ const RelatedProductsList = (props) => {
 RelatedProductsList.propTypes = {
   allProps: propTypes.any,
   handleProductChange: propTypes.any,
-  state: propTypes.object
   };
 
 export default RelatedProductsList;

--- a/client/src/relatedProducts/RelatedProductsView/RelatedProductsList.jsx
+++ b/client/src/relatedProducts/RelatedProductsView/RelatedProductsList.jsx
@@ -9,8 +9,8 @@ const RelatedProductsList = (props) => {
     <div className='relatedProductsListContainer'>
       <h2>Related Products:</h2>
     <div className='relatedProductsList'>
-    {props.allProps.map(product => {
-      return <div key={product.id}>
+    {props.allProps.map((product, i) => {
+      return <div key={i}>
         <RelatedProductsCard
                key={product.itemId}
                name={product.itemName}

--- a/client/src/relatedProducts/YourOutfitView/YourOutfitCard.jsx
+++ b/client/src/relatedProducts/YourOutfitView/YourOutfitCard.jsx
@@ -19,10 +19,10 @@ const getStars = function (starsObject) {
 };
 
 const YourOutfitCard = (props) => {
-  //console.log(`card props: ${JSON.stringify(props)}`)
   return (
     <div className='yourOutfitCard'>
         <h2 className='productName'>{props.outfitProps.name}</h2>
+        <button className='yourOutfitActionButton' onClick={(e) => {props.handleRemoveFromOutfit(props.outfitProps, e)}}>X</button>
         <h3 className='productCategory'>{props.outfitProps.category}</h3>
         <h3 className='originalProductPrice'>{props.outfitProps.originalPrice}</h3>
         <h3 className='saleroductPrice'>{props.outfitProps.salePrice}</h3>
@@ -34,8 +34,9 @@ const YourOutfitCard = (props) => {
 }
 
 YourOutfitCard.propTypes = {
-  outfitProps: propTypes.any,
-  starRating: propTypes.object
+  outfitProps: propTypes.object,
+  starRating: propTypes.object,
+  handleRemoveFromOutfit: propTypes.func
   };
 
   export default YourOutfitCard;

--- a/client/src/relatedProducts/YourOutfitView/YourOutfitList.jsx
+++ b/client/src/relatedProducts/YourOutfitView/YourOutfitList.jsx
@@ -4,19 +4,18 @@ import YourOutfitCard from './YourOutfitCard.jsx';
 import AddToOutfitCard from './AddToOutfitCard.jsx';
 
 const YourOutfitList = (props) => {
-  //console.log(`outfititms ${JSON.stringify(props.outfitItems)}`)
   return (
     <div className='yourOutfitListContainer'>
       <h2>Your Outfit: </h2>
     <div className='yourOutfitList'>
     <AddToOutfitCard handleAddToOutfit={props.handleAddToOutfit} outfitProps={props.outfitProps} state={props.state} />
     {props.outfitItems.map((outfitItem, i) => {
-      //console.log(`🐥 outfitItembeing cardified: ${JSON.stringify(outfitItem)}`)
       return (<div className='outfitItem' key={i}>
                <YourOutfitCard
                 key={outfitItem.id}
                 outfitProps={outfitItem}
                 starRating={props.state.ratings}
+                handleRemoveFromOutfit={props.handleRemoveFromOutfit}
                 />
              </div>)
     })}
@@ -27,9 +26,10 @@ const YourOutfitList = (props) => {
 
 YourOutfitList.propTypes = {
   handleAddToOutfit: propTypes.func,
-  outfitProps: propTypes.any,
+  handleRemoveFromOutfit: propTypes.func,
+  outfitProps: propTypes.object,
   state: propTypes.object,
-  outfitItems: propTypes.array
+  outfitItems: propTypes.array,
   };
 
 export default YourOutfitList;

--- a/client/src/relatedProducts/YourOutfitView/YourOutfitList.jsx
+++ b/client/src/relatedProducts/YourOutfitView/YourOutfitList.jsx
@@ -4,7 +4,7 @@ import YourOutfitCard from './YourOutfitCard.jsx';
 import AddToOutfitCard from './AddToOutfitCard.jsx';
 
 const YourOutfitList = (props) => {
-  console.log(`outfititms ${JSON.stringify(props.outfitItems)}`)
+  //console.log(`outfititms ${JSON.stringify(props.outfitItems)}`)
   return (
     <div className='yourOutfitListContainer'>
       <h2>Your Outfit: </h2>


### PR DESCRIPTION
-Outfit list functionality largely accounted for. Items can be added and removed, and changes persist through local storage on page change/refresh
-Stars included on related products/ outfit list items. I have an issue here I will have to talk to y'all about to get some input, as the stars currently reflect the rating of whatever the main product is. I will need to figure out how to get star ratings of each related product that displays
-Original price strikethrough occurs when there is a sale price, which appears in red. This doesn't seem to come up very often for the default style