### PR TITLE
Related items

### DIFF
--- a/client/dist/index.html
+++ b/client/dist/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <link rel="stylesheet" href="./styles/displayImageGallery.css"/>
@@ -6,6 +7,7 @@
     <link rel="stylesheet" href="./styles/relatedProducts.css"/>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet">
+    <title>FEC Project</title>
     </head>
     <body>
       <div id="app"></div>

--- a/client/dist/styles/relatedProducts.css
+++ b/client/dist/styles/relatedProducts.css
@@ -51,7 +51,7 @@ YOUR OUTFIT STYLING
 
 .yourOutfitList {
   display: flex;
-  border: solid;
+
 }
 .yourOutfitCardList {
   flex-direction: row;

--- a/client/src/relatedProducts/RelatedProductsView/ClickTracker.jsx
+++ b/client/src/relatedProducts/RelatedProductsView/ClickTracker.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+class ClickTracker extends React.component {
+  constructor() {
+    super(props);
+  }
+
+  render() {
+    return (
+      <h1>hi</h1>
+    )
+  }
+}
+
+export default ClickTracker

--- a/client/src/relatedProducts/RelatedProductsView/RelatedProducts.jsx
+++ b/client/src/relatedProducts/RelatedProductsView/RelatedProducts.jsx
@@ -40,9 +40,9 @@ export default class RelatedProducts extends React.Component {
   }
 
   componentDidMount () {
-    let product = this.product()
-    let getStyle = this.style()
-    let outFitData = this.outFit()
+    let product = this.product();
+    let getStyle = this.style();
+    let outFitData = this.outFit();
     let reviewData = this.reviews();
 
     product.then(data => {
@@ -76,14 +76,16 @@ export default class RelatedProducts extends React.Component {
 
   componentDidUpdate (prevProps, prevState) {
     if (prevProps.state.product_id !== this.props.state.product_id) {
-      let product = this.product()
-      let getStyle = this.style()
-      let outFitData = this.outFit()
+      let product = this.product();
+      let getStyle = this.style();
+      let outFitData = this.outFit();
+      let reviewData = this.reviews();
 
       product.then(data => {
         getStyle.then(styleData => {
           outFitData.then(fitData => {
             reviewData.then(reviewData => {
+
             let allPropsObj = helper.compileRelatedProductsDataToProps(data, styleData)
             let values = [];
             let keys = Object.keys(localStorage);
@@ -183,6 +185,8 @@ export default class RelatedProducts extends React.Component {
       if (this.state.yourOutfitItems.some(({product_id}) => product_id === outfitItem.product_id)) {
         alert('Item already in outfit')
       } else {
+        let itemWithReviews = outfitItem;
+        itemWithReviews['reviews'] = this.props.state.ratings;
         localStorage.setItem(outfitItem.product_id, JSON.stringify(outfitItem));
         this.setState({
           yourOutfitItems: [...this.state.yourOutfitItems, outfitItem]

--- a/client/src/relatedProducts/RelatedProductsView/RelatedProductsCard.jsx
+++ b/client/src/relatedProducts/RelatedProductsView/RelatedProductsCard.jsx
@@ -12,10 +12,14 @@ const getStars = function (starsObject) {
     total = starsObject[star] * star + total;
   }
 
+
   let average = total / numberOfRatings;
   let htmlElements = Stars(average);
+
   return htmlElements;
 };
+
+
 
 const RelatedProductsCard = (props) => {
 
@@ -41,8 +45,9 @@ const RelatedProductsCard = (props) => {
             )
           }
         })()}
-        <img src={props.photo || 'https://lightwidget.com/wp-content/uploads/local-file-not-found-480x488.png'}></img>
-        <span className="reviewStars">{getStars(props.starRating)}</span>
+        <img src={props.photo || 'https://lightwidget.com/wp-content/uploads/local-file-not-found-480x488.png'} alt='clothing product'></img>
+
+        <span className="reviewStars">{getStars(props.starRating.ratings)}</span>
         </div>
     </div>
   )

--- a/client/src/relatedProducts/RelatedProductsView/RelatedProductsCard.jsx
+++ b/client/src/relatedProducts/RelatedProductsView/RelatedProductsCard.jsx
@@ -12,11 +12,16 @@ const getStars = function (starsObject) {
     total = starsObject[star] * star + total;
   }
 
-
   let average = total / numberOfRatings;
   let htmlElements = Stars(average);
 
-  return htmlElements;
+  if (numberOfRatings !== 0) {
+    return htmlElements
+  } else {
+    return <div className='stars'>{htmlElements.props.children[0]}</div>
+  }
+
+
 };
 
 

--- a/client/src/relatedProducts/RelatedProductsView/RelatedProductsList.jsx
+++ b/client/src/relatedProducts/RelatedProductsView/RelatedProductsList.jsx
@@ -17,10 +17,11 @@ const RelatedProductsList = (props) => {
         features={product.features}
         handleProductChange={props.handleProductChange}
         handleCompareItems={props.handleCompareItems}
-        starRating={product.starRating}
+        starRating={props.reviews[index]}
        />
      </div>
-  })
+  });
+
   let prevButton;
   if (props.displayedProductsIndices[0] > 0) {
     prevButton =  <button
@@ -38,6 +39,7 @@ const RelatedProductsList = (props) => {
     className='nextButton'
     onClick={() => {props.handleNextClick()}} >Next</button>
   }
+
 
   return (
     <div className='relatedProductsListContainer'>
@@ -62,7 +64,8 @@ RelatedProductsList.propTypes = {
   handleCompareItems: propTypes.func,
   handlePrevClick: propTypes.func,
   handleNextClick: propTypes.func,
-  displayedProductsIndices: propTypes.array
+  displayedProductsIndices: propTypes.array,
+  reviews: propTypes.array
   };
 
 export default RelatedProductsList;

--- a/client/src/relatedProducts/YourOutfitView/YourOutfitCard.jsx
+++ b/client/src/relatedProducts/YourOutfitView/YourOutfitCard.jsx
@@ -10,15 +10,17 @@ const getStars = function (starsObject) {
     numberOfRatings = numberOfRatings + Number(starsObject[star]);
     total = starsObject[star] * star + total;
   }
-
   let average = total / numberOfRatings;
-
   let htmlElements = Stars(average);
-
   return htmlElements;
 };
 
+
 const YourOutfitCard = (props) => {
+
+  let outfitItemRatings = JSON.parse(localStorage.getItem(props.id)).reviews;
+
+
   return (
     <div className='yourOutfitCard'>
         <h2 className='productName'>{props.outfitProps.name}</h2>
@@ -27,7 +29,7 @@ const YourOutfitCard = (props) => {
         <h3 className='originalProductPrice'>{props.outfitProps.originalPrice}</h3>
         <h3 className='saleroductPrice'>{props.outfitProps.salePrice}</h3>
         <img src={props.outfitProps.photoUrl.thumbnail_url} alt='clothing product'></img>
-        <div className="reviewStars">{getStars(props.starRating)}</div>
+        <div className="reviewStars">{getStars(outfitItemRatings)}</div>
     </div>
   )
 
@@ -36,7 +38,8 @@ const YourOutfitCard = (props) => {
 YourOutfitCard.propTypes = {
   outfitProps: propTypes.object,
   starRating: propTypes.object,
-  handleRemoveFromOutfit: propTypes.func
+  handleRemoveFromOutfit: propTypes.func,
+  id: propTypes.number
   };
 
   export default YourOutfitCard;

--- a/client/src/relatedProducts/YourOutfitView/YourOutfitCard.jsx
+++ b/client/src/relatedProducts/YourOutfitView/YourOutfitCard.jsx
@@ -26,7 +26,7 @@ const YourOutfitCard = (props) => {
         <h3 className='productCategory'>{props.outfitProps.category}</h3>
         <h3 className='originalProductPrice'>{props.outfitProps.originalPrice}</h3>
         <h3 className='saleroductPrice'>{props.outfitProps.salePrice}</h3>
-        <img src={props.outfitProps.photoUrl.thumbnail_url}></img>
+        <img src={props.outfitProps.photoUrl.thumbnail_url} alt='clothing product'></img>
         <div className="reviewStars">{getStars(props.starRating)}</div>
     </div>
   )

--- a/client/src/relatedProducts/YourOutfitView/YourOutfitCard.jsx
+++ b/client/src/relatedProducts/YourOutfitView/YourOutfitCard.jsx
@@ -12,9 +12,13 @@ const getStars = function (starsObject) {
   }
   let average = total / numberOfRatings;
   let htmlElements = Stars(average);
-  return htmlElements;
-};
 
+  if (numberOfRatings !== 0) {
+    return htmlElements
+  } else {
+    return <div className='stars'>{htmlElements.props.children[0]}</div>
+  }
+};
 
 const YourOutfitCard = (props) => {
 

--- a/client/src/relatedProducts/YourOutfitView/YourOutfitCard.jsx
+++ b/client/src/relatedProducts/YourOutfitView/YourOutfitCard.jsx
@@ -21,9 +21,7 @@ const getStars = function (starsObject) {
 };
 
 const YourOutfitCard = (props) => {
-
   let outfitItemRatings = JSON.parse(localStorage.getItem(props.id)).reviews;
-
 
   return (
     <div className='yourOutfitCard'>

--- a/client/src/relatedProducts/YourOutfitView/YourOutfitList.jsx
+++ b/client/src/relatedProducts/YourOutfitView/YourOutfitList.jsx
@@ -29,7 +29,7 @@ YourOutfitList.propTypes = {
   handleRemoveFromOutfit: propTypes.func,
   outfitProps: propTypes.object,
   state: propTypes.object,
-  outfitItems: propTypes.array,
+  outfitItems: propTypes.array
   };
 
 export default YourOutfitList;

--- a/client/src/relatedProducts/YourOutfitView/YourOutfitList.jsx
+++ b/client/src/relatedProducts/YourOutfitView/YourOutfitList.jsx
@@ -4,6 +4,7 @@ import YourOutfitCard from './YourOutfitCard.jsx';
 import AddToOutfitCard from './AddToOutfitCard.jsx';
 
 const YourOutfitList = (props) => {
+
   return (
     <div className='yourOutfitListContainer'>
       <h2>Your Outfit: </h2>
@@ -13,6 +14,7 @@ const YourOutfitList = (props) => {
         return (<div className='outfitItem' key={i}>
                  <YourOutfitCard
                   key={outfitItem.id}
+                  id={outfitItem.product_id}
                   outfitProps={outfitItem}
                   starRating={props.state.ratings}
                   handleRemoveFromOutfit={props.handleRemoveFromOutfit}


### PR DESCRIPTION
Fixed stars in related products for related product list and your outfit list. They were previously displaying the star rating of the main product displayed for all related products and all outfit items. Added an api call to reviews/meta for related products to get data for each item, and started storing star rating in local storage for outfit items so it persisted through product change.